### PR TITLE
Add '-f ' to 'rm' in 'clean' target.

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ install:
 
 clean:
 	ocamlbuild -clean
-	- rm *~
-	- rm *.json
-	-rm filesys.ml
+	- rm -f *~
+	- rm -f *.json
+	-rm -f filesys.ml
 


### PR DESCRIPTION
A tweak to the makefile to avoid this:

``` bash
$ make clean
ocamlbuild -clean
rm *~
rm: cannot remove ‘*~’: No such file or directory
makefile:19: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm *.json
rm: cannot remove ‘*.json’: No such file or directory
makefile:19: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
```
